### PR TITLE
Restructure keys to include /buildkite prefix

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,26 @@
+# Installation
+
+The hooks needs to be installed directly in the agent so that secrets can be downloaded before jobs attempt checking out your repository. We are going to assume that buildkite has been installed at `/buildkite`, but this will vary depending on your operating system. Change the instructions accordingly.
+
+```
+# clone to a path your buildkite-agent can access
+git clone https://github.com/buildkite/elastic-ci-stack-secrets-manager-hooks.git /buildkite/sm_secrets
+```
+
+Modify your agent's global hooks (see [https://buildkite.com/docs/agent/v3/hooks#global-hooks](https://buildkite.com/docs/agent/v3/hooks#global-hooks)):
+
+## `${BUILDKITE_ROOT}/hooks/environment`
+
+```bash
+if [[ "${SM_SECRETS_HOOKS_ENABLED:-1}" == "1" ]] ; then
+  source /buildkite/sm_secrets/hooks/environment
+fi
+```
+
+## `${BUILDKITE_ROOT}/hooks/pre-exit`
+
+```bash
+if [[ "${SM_SECRETS_HOOKS_ENABLED:-1}" == "1" ]] ; then
+  source /buildkite/sm_secrets/hooks/pre-exit
+fi
+```

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Different types of secrets are supported and exposed to your builds in appropria
 
 When run via the agent environment and pre-exit hook, your builds will check the following Secrets Manager paths:
 
-* `/buildkite/{org_slug}/global/ssh-private-key`
-* `/buildkite/{org_slug}/global/git-credentials`
-* `/buildkite/{org_slug}/global/env/{env_name}`
-* `/buildkite/{org_slug}/pipeline/{pipeline_slug}/ssh-private-key`
-* `/buildkite/{org_slug}/pipeline/{pipeline_slug}/git-credentials`
-* `/buildkite/{org_slug}/pipeline/{pipeline_slug}/env/{env_name}`
+* `buildkite/{org_slug}/ssh-private-key`
+* `buildkite/{org_slug}/git-credentials`
+* `buildkite/{org_slug}/env/{env_name}`
+* `buildkite/{org_slug}/pipeline/{pipeline_slug}/ssh-private-key`
+* `buildkite/{org_slug}/pipeline/{pipeline_slug}/git-credentials`
+* `buildkite/{org_slug}/pipeline/{pipeline_slug}/env/{env_name}`
 
 Inside those secrets, the following keys will be checked:
 

--- a/README.md
+++ b/README.md
@@ -8,47 +8,16 @@ Different types of secrets are supported and exposed to your builds in appropria
 - Environment Variables for strings
 - `git-credential` via git's credential.helper
 
-## Installation
-
-The hooks needs to be installed directly in the agent so that secrets can be downloaded before jobs attempt checking out your repository. We are going to assume that buildkite has been installed at `/buildkite`, but this will vary depending on your operating system. Change the instructions accordingly.
-
-```
-# clone to a path your buildkite-agent can access
-git clone https://github.com/buildkite/elastic-ci-stack-secrets-manager-hooks.git /buildkite/sm_secrets
-```
-
-Modify your agent's global hooks (see [https://buildkite.com/docs/agent/v3/hooks#global-hooks](https://buildkite.com/docs/agent/v3/hooks#global-hooks)):
-
-### `${BUILDKITE_ROOT}/hooks/environment`
-
-```bash
-if [[ "${SM_SECRETS_HOOKS_ENABLED:-1}" == "1" ]] ; then
-  export BUILDKITE_SECRETS_MANAGER_PREFIX="elastic-ci-stack"
-
-  source /buildkite/sm_secrets/hooks/environment
-fi
-```
-
-### `${BUILDKITE_ROOT}/hooks/pre-exit`
-
-```bash
-if [[ "${SM_SECRETS_HOOKS_ENABLED:-1}" == "1" ]] ; then
-  export BUILDKITE_SECRETS_MANAGER_PREFIX="elastic-ci-stack"
-
-  source /buildkite/sm_secrets/hooks/pre-exit
-fi
-```
-
 ## Usage
 
 When run via the agent environment and pre-exit hook, your builds will check the following Secrets Manager paths:
 
-* `{prefix}/global/ssh-private-key`
-* `{prefix}/global/git-credentials`
-* `{prefix}/global/env/{env_name}`
-* `{prefix}/pipeline/{pipeline_slug}/ssh-private-key`
-* `{prefix}/pipeline/{pipeline_slug}/git-credentials`
-* `{prefix}/pipeline/{pipeline_slug}/env/{env_name}`
+* `/buildkite/{org_slug}/global/ssh-private-key`
+* `/buildkite/{org_slug}/global/git-credentials`
+* `/buildkite/{org_slug}/global/env/{env_name}`
+* `/buildkite/{org_slug}/pipeline/{pipeline_slug}/ssh-private-key`
+* `/buildkite/{org_slug}/pipeline/{pipeline_slug}/git-credentials`
+* `/buildkite/{org_slug}/pipeline/{pipeline_slug}/env/{env_name}`
 
 Inside those secrets, the following keys will be checked:
 
@@ -68,9 +37,8 @@ ssh-keygen -t rsa -b 4096 -f id_rsa_buildkite
 pbcopy < id_rsa_buildkite.pub # paste this into your github deploy key
 
 # create a managed secret with the private key
-export secrets_manager_prefix="elastic-ci-stack"
 aws secretsmanager create-secret \
-  --name "${secrets_manager_prefix}/global/ssh-private-key" \
+  --name "/buildkite/my-org/ssh-private-key" \
   --secret-binary file://id_rsa_buildkite
 ```
 
@@ -79,9 +47,8 @@ aws secretsmanager create-secret \
 This example stores a custom value for `MY_FAVORITE_LLAMA`, with a value of `they are all good llamas`.
 
 ```bash
-export secrets_manager_prefix="elastic-ci-stack"
 aws secretsmanager create-secret \
-  --name "${secrets_manager_prefix}/global/env/MY_FAVORITE_LLAMA" \
+  --name "/buildkite/my-org/env/MY_FAVORITE_LLAMA" \
   --secret-string "they are all good llamas"
 ```
 
@@ -95,9 +62,8 @@ https://user:password@host/path/to/repo
 
 ```bash
 # create a managed secret with the private key
-export secrets_manager_prefix="elastic-ci-stack"
 aws secretsmanager create-secret \
-  --name "${secrets_manager_prefix}/global/git-credentials" \
+  --name "/buildkite/my-org/git-credentials" \
   --secret-binary "https://user:password@host/path/to/repo"
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pbcopy < id_rsa_buildkite.pub # paste this into your github deploy key
 
 # create a managed secret with the private key
 aws secretsmanager create-secret \
-  --name "/buildkite/my-org/ssh-private-key" \
+  --name "buildkite/my-org/ssh-private-key" \
   --secret-binary file://id_rsa_buildkite
 ```
 
@@ -48,7 +48,7 @@ This example stores a custom value for `MY_FAVORITE_LLAMA`, with a value of `the
 
 ```bash
 aws secretsmanager create-secret \
-  --name "/buildkite/my-org/env/MY_FAVORITE_LLAMA" \
+  --name "buildkite/my-org/env/MY_FAVORITE_LLAMA" \
   --secret-string "they are all good llamas"
 ```
 
@@ -63,7 +63,7 @@ https://user:password@host/path/to/repo
 ```bash
 # create a managed secret with the private key
 aws secretsmanager create-secret \
-  --name "/buildkite/my-org/git-credentials" \
+  --name "buildkite/my-org/git-credentials" \
   --secret-binary "https://user:password@host/path/to/repo"
 ```
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -8,7 +8,9 @@ basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
 export TMPDIR=${TMPDIR:-/tmp}
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
-readonly prefix="${BUILDKITE_SECRETS_MANAGER_PREFIX:-elastic-ci-stack}"
+
+# A non-configurable prefix used on all secrets
+readonly secret_prefix="buildkite/${BUILDKITE_ORG_SLUG}"
 
 debug() {
   if [[ "${BUILDKITE_SECRETS_MANAGER_DEBUG:-false}" =~ (true|on|1) ]] ; then
@@ -16,8 +18,8 @@ debug() {
   fi
 }
 
-echo "~~~ Downloading secrets from AWS Secrets Manager" >&2;
-debug "Searching in prefix ${prefix} in region ${AWS_DEFAULT_REGION}"
+echo "~~~ Loading secrets from AWS Secrets Manager" >&2;
+debug "Searching in prefix ${secret_prefix} in region ${AWS_DEFAULT_REGION}"
 
 # Read all the secret keys into an array
 secrets=()
@@ -34,8 +36,8 @@ fi
 # First up we look for ssh keys if the repository is ssh
 if [[ "${BUILDKITE_REPO:-}" =~ ^git ]] ; then
   ssh_key_paths=(
-    "${prefix}/global/ssh-private-key"
-    "${prefix}/pipeline/${BUILDKITE_PIPELINE_SLUG}/ssh-private-key"
+    "${secret_prefix}/ssh-private-key"
+    "${secret_prefix}/pipeline/${BUILDKITE_PIPELINE_SLUG}/ssh-private-key"
   )
 
   # Look in our key paths in order, but we'll load them all
@@ -67,8 +69,8 @@ fi
 # Otherwise check for git credentials for https, use the first one we find
 if [[ "${BUILDKITE_REPO:-}" =~ ^http ]] ; then
   git_credentials_paths=(
-    "${prefix}/global/git-credentials"
-    "${prefix}/pipeline/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
+    "${secret_prefix}/git-credentials"
+    "${secret_prefix}/pipeline/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
   )
 
   git_credentials=()
@@ -91,8 +93,8 @@ fi
 
 # Finally look for environment variables
 env_path_prefixes=(
-  "${prefix}/global/env/"
-  "${prefix}/pipeline/${BUILDKITE_PIPELINE_SLUG}/env/"
+  "${secret_prefix}/env/"
+  "${secret_prefix}/pipeline/${BUILDKITE_PIPELINE_SLUG}/env/"
 )
 
 for secret_name in ${secrets[*]} ; do
@@ -108,9 +110,7 @@ for secret_name in ${secrets[*]} ; do
       secret_env_key=$(basename $secret_name)
       export "$secret_env_key"="$secret_value"
     else
-      debug "didn't match $secret_name"
+      debug "Env $secret_name didn't match $env_path_prefix"
     fi
   done
 done
-
-

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,10 +1,6 @@
 #!/bin/bash
 
 sm() {
-  # if ! aws help | grep "secretsmanager" ; then
-  #   echo "Your aws-cli doesn't support secretsmanager" >&2
-  #   exit 1
-  # fi
   aws secretsmanager "$@"
 }
 


### PR DESCRIPTION
This changes ditches the arbitrary prefix with `buildkite/{org_slug}` based on discussion in https://github.com/buildkite/elastic-ci-stack-for-aws/pull/469.