### PR TITLE
Simplify down to queue-based git credentials

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,11 +9,11 @@ git clone https://github.com/buildkite/elastic-ci-stack-secrets-manager-hooks.gi
 
 Modify your agent's global hooks (see [https://buildkite.com/docs/agent/v3/hooks#global-hooks](https://buildkite.com/docs/agent/v3/hooks#global-hooks)):
 
-## `${BUILDKITE_ROOT}/hooks/environment`
+## `${BUILDKITE_ROOT}/hooks/pre-command`
 
 ```bash
 if [[ "${SM_SECRETS_HOOKS_ENABLED:-1}" == "1" ]] ; then
-  source /buildkite/sm_secrets/hooks/environment
+  source /buildkite/sm_secrets/hooks/pre-command
 fi
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ The following credential types are supported:
 
 When run via the agent pre-checkout and pre-exit hook, your builds will check the following Secrets Manager paths:
 
-* `buildkite/{queue_name}/{pipeline_slug}/ssh-private-key`
-* `buildkite/{queue_name}/{pipeline_slug}/git-credentials`
+* `buildkite/{org-slug}/{queue-name}/ssh-private-key`
+* `buildkite/{org-slug}/{queue-name}/{pipeline-slug}/ssh-private-key`
+* `buildkite/{org-slug}/{queue-name}/git-credentials`
+* `buildkite/{org-slug}/{queue-name}/{pipeline-slug}/git-credentials`
 
-Both of these secrets use the `SecretBinary` type.
+All secrets use the `SecretBinary` type.
 
 ## Uploading Secrets
 
@@ -29,7 +31,7 @@ pbcopy < id_rsa_buildkite.pub # paste this into your github deploy key
 
 # create a managed secret with the private key
 aws secretsmanager create-secret \
-  --name "buildkite/<queue-name>/<pipeline-slug>/ssh-private-key" \
+  --name "buildkite/<org-slug>/<queue-name>/<pipeline-slug>/ssh-private-key" \
   --secret-binary file://id_rsa_buildkite
 ```
 
@@ -39,7 +41,7 @@ Here's an example for how you'd configure git credentials for a pipeline, using 
 
 ```bash
 aws secretsmanager create-secret \
-  --name "buildkite/<queue-name>/<pipeline-slug>/git-credentials" \
+  --name "buildkite/<org-slug>/<queue-name>/<pipeline-slug>/git-credentials" \
   --secret-string "https://<username>:<access-token>@github.com"
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All secrets use the `SecretBinary` type.
 
 ### Setting SSH Keys for Git Checkouts
 
-This example uploads an ssh key for a git+ssh checkout for a pipeline:
+This example uploads an ssh key for a git+ssh checkout for all pipelines:
 
 ```bash
 # generate a deploy key for your project
@@ -31,13 +31,29 @@ pbcopy < id_rsa_buildkite.pub # paste this into your github deploy key
 
 # create a managed secret with the private key
 aws secretsmanager create-secret \
+  --name "buildkite/<org-slug>/<queue-name>/ssh-private-key" \
+  --secret-binary file://id_rsa_buildkite
+```
+
+Credentials can also be set for a specific pipeline with:
+
+```bash
+aws secretsmanager create-secret \
   --name "buildkite/<org-slug>/<queue-name>/<pipeline-slug>/ssh-private-key" \
   --secret-binary file://id_rsa_buildkite
 ```
 
 ### Configuring Git Credentials
 
-Here's an example for how you'd configure git credentials for a pipeline, using a [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/):
+Here's an example for how you'd configure git credentials for all pipelines, using a [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/):
+
+```bash
+aws secretsmanager create-secret \
+  --name "buildkite/<org-slug>/<queue-name>/git-credentials" \
+  --secret-string "https://<username>:<access-token>@github.com"
+```
+
+Credentials can also be set for a specific pipeline with:
 
 ```bash
 aws secretsmanager create-secret \

--- a/README.md
+++ b/README.md
@@ -1,35 +1,26 @@
-# AWS Secrets Manager Buildkite Hooks
+# AWS Secrets Manager Agent Hooks
 
-A set of agent hooks that expose secrets to build steps via [Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/).
+A set of agent hooks that fetch credentials from [Amazon Secrets Manager](https://aws.amazon.com/secrets-manager/) for checking out a project.
 
-Different types of secrets are supported and exposed to your builds in appropriate ways:
+The following credential types are supported:
 
 - `ssh-agent` for SSH Private Keys
-- Environment Variables for strings
 - `git-credential` via git's credential.helper
 
 ## Usage
 
-When run via the agent environment and pre-exit hook, your builds will check the following Secrets Manager paths:
+When run via the agent pre-checkout and pre-exit hook, your builds will check the following Secrets Manager paths:
 
-* `buildkite/{org_slug}/ssh-private-key`
-* `buildkite/{org_slug}/git-credentials`
-* `buildkite/{org_slug}/env/{env_name}`
-* `buildkite/{org_slug}/pipeline/{pipeline_slug}/ssh-private-key`
-* `buildkite/{org_slug}/pipeline/{pipeline_slug}/git-credentials`
-* `buildkite/{org_slug}/pipeline/{pipeline_slug}/env/{env_name}`
+* `buildkite/{queue_name}/{pipeline_slug}/ssh-private-key`
+* `buildkite/{queue_name}/{pipeline_slug}/git-credentials`
 
-For those secrets, the following types will be expected:
-
-* `ssh-private-key` is a `SecretBinary` that contains an ssh key for ssh git checkouts
-* `git-credentials` is a `SecretBinary` that stores git credentials for https git checkouts
-* `env/{env_name}` will be a `SecretString` and `{env_name}` will be the environment key that is set
+Both of these secrets use the `SecretBinary` type.
 
 ## Uploading Secrets
 
 ### Setting SSH Keys for Git Checkouts
 
-This example uploads an ssh key that would be used globally across your organization.
+This example uploads an ssh key for a git+ssh checkout for a pipeline:
 
 ```bash
 # generate a deploy key for your project
@@ -38,35 +29,17 @@ pbcopy < id_rsa_buildkite.pub # paste this into your github deploy key
 
 # create a managed secret with the private key
 aws secretsmanager create-secret \
-  --name "buildkite/my-org/ssh-private-key" \
+  --name "buildkite/<queue-name>/<pipeline-slug>/ssh-private-key" \
   --secret-binary file://id_rsa_buildkite
-```
-
-### Setting Environment Variables
-
-Here's an example of how you would set an env of `MY_FAVORITE_LLAMA`, with a value of `they are all good llamas` for all builds across all pipelines.
-
-```bash
-aws secretsmanager create-secret \
-  --name "buildkite/my-org/env/MY_FAVORITE_LLAMA" \
-  --secret-string "they are all good llamas"
 ```
 
 ### Configuring Git Credentials
 
-Here's an example for how you'd configure a global git credential for the entire stack, using a [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/):
+Here's an example for how you'd configure git credentials for a pipeline, using a [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/):
 
 ```bash
 aws secretsmanager create-secret \
-  --name "buildkite/<org-slug>/git-credentials" \
-  --secret-string "https://<username>:<access-token>@github.com"
-```
-
-You can also override it a per-pipeline basis:
-
-```
-aws secretsmanager create-secret \
-  --name "buildkite/<org-slug>/pipeline/<pipeline-slug>/git-credentials" \
+  --name "buildkite/<queue-name>/<pipeline-slug>/git-credentials" \
   --secret-string "https://<username>:<access-token>@github.com"
 ```
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -9,8 +9,10 @@ basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 export TMPDIR=${TMPDIR:-/tmp}
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
 
-# A non-configurable prefix used on all secrets
-readonly secret_prefix="buildkite/${BUILDKITE_ORGANIZATION_SLUG}"
+if [[ -z "${BUILDKITE_SECRETS_PREFIX:-}" ]] ; then
+  echo "Must set a prefix with BUILDKITE_SECRETS_PREFIX"
+  exit 1
+fi
 
 debug() {
   if [[ "${BUILDKITE_SECRETS_MANAGER_DEBUG:-false}" =~ (true|on|1) ]] ; then
@@ -19,7 +21,7 @@ debug() {
 }
 
 echo "~~~ Loading secrets from AWS Secrets Manager" >&2;
-debug "Searching in prefix ${secret_prefix} in region ${AWS_DEFAULT_REGION}"
+debug "Searching in prefix ${BUILDKITE_SECRETS_PREFIX} in region ${AWS_DEFAULT_REGION}"
 
 # Read all the secret keys into an array
 secrets=()
@@ -36,8 +38,7 @@ fi
 # First up we look for ssh keys if the repository is ssh
 if [[ "${BUILDKITE_REPO:-}" =~ ^git ]] ; then
   ssh_key_paths=(
-    "${secret_prefix}/ssh-private-key"
-    "${secret_prefix}/pipeline/${BUILDKITE_PIPELINE_SLUG}/ssh-private-key"
+    "${BUILDKITE_SECRETS_PREFIX}/${BUILDKITE_PIPELINE_SLUG}/ssh-private-key"
   )
 
   # Look in our key paths in order, but we'll load them all
@@ -69,8 +70,7 @@ fi
 # Otherwise check for git credentials for https, use the first one we find
 if [[ "${BUILDKITE_REPO:-}" =~ ^http ]] ; then
   git_credentials_paths=(
-    "${secret_prefix}/git-credentials"
-    "${secret_prefix}/pipeline/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
+    "${BUILDKITE_SECRETS_PREFIX}/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
   )
 
   git_credentials=()
@@ -90,27 +90,3 @@ if [[ "${BUILDKITE_REPO:-}" =~ ^http ]] ; then
     GIT_CONFIG_PARAMETERS=$( IFS=' '; echo -n "${git_credentials[*]}" )
   fi
 fi
-
-# Finally look for environment variables
-env_path_prefixes=(
-  "${secret_prefix}/env/"
-  "${secret_prefix}/pipeline/${BUILDKITE_PIPELINE_SLUG}/env/"
-)
-
-for secret_name in ${secrets[*]} ; do
-  for env_path_prefix in ${env_path_prefixes[*]} ; do
-    if [[ $secret_name =~ ^$env_path_prefix ]] ; then
-      echo "Found env $secret_name" >&2;
-
-      if ! secret_value=$(sm_secret_get "$secret_name") ; then
-        echo "+++ :warning: Failed to get secret $secret_name" >&2;
-        exit 1
-      fi
-
-      secret_env_key=$(basename $secret_name)
-      export "$secret_env_key"="$secret_value"
-    else
-      debug "Env $secret_name didn't match $env_path_prefix"
-    fi
-  done
-done

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -38,6 +38,7 @@ fi
 # First up we look for ssh keys if the repository is ssh
 if [[ "${BUILDKITE_REPO:-}" =~ ^git ]] ; then
   ssh_key_paths=(
+    "${BUILDKITE_SECRETS_PREFIX}/ssh-private-key"
     "${BUILDKITE_SECRETS_PREFIX}/${BUILDKITE_PIPELINE_SLUG}/ssh-private-key"
   )
 
@@ -70,6 +71,7 @@ fi
 # Otherwise check for git credentials for https, use the first one we find
 if [[ "${BUILDKITE_REPO:-}" =~ ^http ]] ; then
   git_credentials_paths=(
+    "${BUILDKITE_SECRETS_PREFIX}/git-credentials"
     "${BUILDKITE_SECRETS_PREFIX}/${BUILDKITE_PIPELINE_SLUG}/git-credentials"
   )
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -14,8 +14,8 @@ setup() {
 {
     "SecretList": [
         {
-            "ARN": "arn:aws:secretsmanager:us-east-1:xxxxx:secret:buildkite/my-queue/my-pipeline/ssh-private-key-xxxx",
-            "Name": "buildkite/my-queue/my-pipeline/ssh-private-key"
+            "ARN": "arn:aws:secretsmanager:us-east-1:xxxxx:secret:buildkite/my-org/my-queue/my-pipeline/ssh-private-key-xxxx",
+            "Name": "buildkite/my-org/my-queue/my-pipeline/ssh-private-key"
         }
     ]
 }
@@ -24,8 +24,8 @@ EOF
 {
     "SecretList": [
         {
-            "ARN": "arn:aws:secretsmanager:us-east-1:xxxxx:secret:buildkite/my-queue/my-pipeline/git-credentials-xxxx",
-            "Name": "buildkite/my-queue/my-pipeline/git-credentials"
+            "ARN": "arn:aws:secretsmanager:us-east-1:xxxxx:secret:buildkite/my-org/my-queue/my-pipeline/git-credentials-xxxx",
+            "Name": "buildkite/my-org/my-queue/my-pipeline/git-credentials"
         }
     ]
 }
@@ -40,13 +40,13 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=my-pipeline
   export BUILDKITE_REPO=git@github.com:buildkite/llamas.git
   export BUILDKITE_SECRETS_MANAGER_DEBUG=true
-  export BUILDKITE_SECRETS_PREFIX=buildkite/my-queue
+  export BUILDKITE_SECRETS_PREFIX=buildkite/my-org/my-queue
 
   stub ssh-agent "-s : echo export SSH_AGENT_PID=93799"
 
   stub aws \
     "secretsmanager list-secrets : cat $TMP_DIR/ssh-secrets" \
-    "secretsmanager get-secret-value --secret-id buildkite/my-queue/my-pipeline/ssh-private-key --query SecretBinary --output text : echo llamas"
+    "secretsmanager get-secret-value --secret-id buildkite/my-org/my-queue/my-pipeline/ssh-private-key --query SecretBinary --output text : echo llamas"
 
   stub ssh-add \
     "- : cat > $TMP_DIR/ssh-add-input ; echo added ssh key"
@@ -67,11 +67,11 @@ teardown() {
   export BUILDKITE_PIPELINE_SLUG=my-pipeline
   export BUILDKITE_REPO=https://github.com/buildkite/llamas.git
   export BUILDKITE_SECRETS_MANAGER_DEBUG=true
-  export BUILDKITE_SECRETS_PREFIX=buildkite/my-queue
+  export BUILDKITE_SECRETS_PREFIX=buildkite/my-org/my-queue
 
   stub aws \
     "secretsmanager list-secrets : cat $TMP_DIR/git-credentials-secrets" \
-    "secretsmanager get-secret-value --secret-id buildkite/my-queue/my-pipeline/git-credentials --query SecretBinary --output text : echo https://user:password@host/path/to/repo"
+    "secretsmanager get-secret-value --secret-id buildkite/my-org/my-queue/my-pipeline/git-credentials --query SecretBinary --output text : echo https://user:password@host/path/to/repo"
 
   run bash -c "$PWD/hooks/pre-command && $PWD/hooks/pre-exit"
 
@@ -79,7 +79,7 @@ teardown() {
   assert_output --partial "Adding git-credentials"
   assert_output --partial "Setting GIT_CONFIG_PARAMETERS"
 
-  run bash -c "$PWD/git-credential-sm-secrets buildkite/my-queue/my-pipeline/git-credentials"
+  run bash -c "$PWD/git-credential-sm-secrets buildkite/my-org/my-queue/my-pipeline/git-credentials"
 
   assert_success
   assert_output --partial "protocol=https"


### PR DESCRIPTION
After a long discussion with @toolmantim in https://github.com/buildkite/elastic-ci-stack-for-aws/pull/469#, we decided to radically reduce the surface area offered by these hooks.

The addition of queue as a prefix allows for IAM rules to restrict access to a given elastic stack to just that queues secrets. Otherwise all stacks in an AWS account would have access to all secrets. 

We removed env, as once the pipeline is checked out, plugins can be used for secrets management. This keeps these hooks focused on checkout. 